### PR TITLE
doc(readme): Fixing the link to dockerhub.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # debugging-tools
 
-This repo contains the Dockerfile for [armory/debugging-tools](https://cloud.docker.com/u/armory/repository/docker/armory/debugging-tools).
+This repo contains the Dockerfile for [armory/debugging-tools](https://hub.docker.com/r/armory/debugging-tools).
 
 The [`deployment.yml`](https://github.com/armory/docker-debugging-tools/blob/master/deployment.yml) manifest is available to put into your kubernetes cluster.
 ```bash


### PR DESCRIPTION
doce(readme): Fixing the link to dockerhub.

The link is broken, so updating to a valid link.